### PR TITLE
Added simple example configuration to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,23 @@ This extraction is made to work with the [angular-translate][angular_translate] 
 
 `$translate('TRANSLATION')`
 
-## Options
+## Configuration
+
+Simple configuration for `i18nextract` task
+
+```
+i18nextract: {
+  default_options: {
+    src: [ 'src/**/*.js', 'src/**/*.html' ],
+    lang:     ['fr_FR'],
+    dest:     'tmp'
+  }
+}
+```
+
+More examples in [Gruntfile.js](https://github.com/angular-translate/grunt-angular-translate/blob/master/Gruntfile.js)
+
+### Options
 
 Options src and jsonSrc may be specified according to the grunt Configuring tasks guide.
 


### PR DESCRIPTION
Added link to Gruntfile where complete set of example configuration is found + simple configuration to get started without having to guess typical set of required options not browsing project sources.

I had some problems to get task working with only guidance of readme.md.  After short googling and finding https://github.com/angular-translate/grunt-angular-translate/issues/7 I found information what I needed. I thought it would be helpful to have this information directly in Readme.md
