### PR TITLE
Add support for $translate.instant()

### DIFF
--- a/tasks/angular-translate.js
+++ b/tasks/angular-translate.js
@@ -82,12 +82,14 @@ module.exports = function (grunt) {
           switch (regexName) {
             case "HtmlFilterSimpleQuote":
             case "JavascriptServiceSimpleQuote":
+            case "JavascriptServiceInstantSimpleQuote":
             case "JavascriptFilterSimpleQuote":
             case "HtmlNgBindHtml":
               translationKey = translationKey.replace(/\\\'/g, "'");
               break;
             case "HtmlFilterDoubleQuote":
             case "JavascriptServiceDoubleQuote":
+            case "JavascriptServiceInstantDoubleQuote":
             case "JavascriptFilterDoubleQuote":
               translationKey = translationKey.replace(/\\\"/g, '"');
               break;
@@ -107,6 +109,8 @@ module.exports = function (grunt) {
       HtmlNgBindHtml: 'ng-bind-html="\\s*\'((?:\\\\.|[^\'\\\\])*)\'\\s*\\|\\s*translate(:.*?)?\\s*"',
       JavascriptServiceSimpleQuote: '\\$translate\\(\\s*\'((?:\\\\.|[^\'\\\\])*)\'[^\\)]*\\)',
       JavascriptServiceDoubleQuote: '\\$translate\\(\\s*"((?:\\\\.|[^"\\\\])*)"[^\\)]*\\)',
+      JavascriptServiceInstantSimpleQuote: '\\$translate\\.instant\\(\\s*\'((?:\\\\.|[^\'\\\\])*)\'[^\\)]*\\)',
+      JavascriptServiceInstantDoubleQuote: '\\$translate\\.instant\\(\\s*"((?:\\\\.|[^"\\\\])*)"[^\\)]*\\)',
       JavascriptFilterSimpleQuote: '\\$filter\\(\\s*\'translate\'\\s*\\)\\s*\\(\\s*\'((?:\\\\.|[^\'\\\\])*)\'[^\\)]*\\)',
       JavascriptFilterDoubleQuote: '\\$filter\\(\\s*"translate"\\s*\\)\\s*\\(\\s*"((?:\\\\.|[^"\\\\\])*)"[^\\)]*\\)'
     };

--- a/test/expected/00_fr_FR.json
+++ b/test/expected/00_fr_FR.json
@@ -15,6 +15,8 @@
     "SUB.NS.VAL 1.test 2": "",
     "JavascriptServiceSimpleQuote 1/2 with var \"{name}\".": "",
     "JavascriptServiceDoubleQuote 2/2 with var \"{name}\".": "",
+    "JavascriptServiceInstantSimpleQuote 1/2 with var \"{name}\".": "",
+    "JavascriptServiceInstantDoubleQuote 2/2 with var \"{name}\".": "",
     "JavascriptFilter 1/2 with var \"{name}\"": "",
     "JavascriptFilter 2/2 without var": ""
 }

--- a/test/expected/01_fr_FR.json
+++ b/test/expected/01_fr_FR.json
@@ -15,6 +15,8 @@
     "SUB.NS.VAL 1.test 2": null,
     "JavascriptServiceSimpleQuote 1/2 with var \"{name}\".": null,
     "JavascriptServiceDoubleQuote 2/2 with var \"{name}\".": null,
+    "JavascriptServiceInstantSimpleQuote 1/2 with var \"{name}\".": null,
+    "JavascriptServiceInstantDoubleQuote 2/2 with var \"{name}\".": null,
     "JavascriptFilter 1/2 with var \"{name}\"": "my {name} javascript filter",
     "JavascriptFilter 2/2 without var": null
 }

--- a/test/expected/02_fr_FR.json
+++ b/test/expected/02_fr_FR.json
@@ -15,6 +15,8 @@
     "SUB.NS.VAL 1.test 2": "",
     "JavascriptServiceSimpleQuote 1/2 with var \"{name}\".": "",
     "JavascriptServiceDoubleQuote 2/2 with var \"{name}\".": "",
+    "JavascriptServiceInstantSimpleQuote 1/2 with var \"{name}\".": "",
+    "JavascriptServiceInstantDoubleQuote 2/2 with var \"{name}\".": "",
     "JavascriptFilter 1/2 with var \"{name}\"": "my {name} javascript filter",
     "JavascriptFilter 2/2 without var": ""
 }

--- a/test/expected/03_fr_FR.json
+++ b/test/expected/03_fr_FR.json
@@ -15,6 +15,8 @@
     "SUB.NS.VAL 1.test 2": "",
     "JavascriptServiceSimpleQuote 1/2 with var \"{name}\".": "",
     "JavascriptServiceDoubleQuote 2/2 with var \"{name}\".": "",
+    "JavascriptServiceInstantSimpleQuote 1/2 with var \"{name}\".": "",
+    "JavascriptServiceInstantDoubleQuote 2/2 with var \"{name}\".": "",
     "JavascriptFilter 1/2 with var \"{name}\"": "",
     "JavascriptFilter 2/2 without var": ""
 }

--- a/test/expected/04_en_US.json
+++ b/test/expected/04_en_US.json
@@ -15,6 +15,8 @@
     "SUB.NS.VAL 1.test 2": "SUB.NS.VAL 1.test 2",
     "JavascriptServiceSimpleQuote 1/2 with var \"{name}\".": "JavascriptServiceSimpleQuote 1/2 with var \"{name}\".",
     "JavascriptServiceDoubleQuote 2/2 with var \"{name}\".": "JavascriptServiceDoubleQuote 2/2 with var \"{name}\".",
+    "JavascriptServiceInstantSimpleQuote 1/2 with var \"{name}\".": "JavascriptServiceInstantSimpleQuote 1/2 with var \"{name}\".",
+    "JavascriptServiceInstantDoubleQuote 2/2 with var \"{name}\".": "JavascriptServiceInstantDoubleQuote 2/2 with var \"{name}\".",
     "JavascriptFilter 1/2 with var \"{name}\"": "JavascriptFilter 1/2 with var \"{name}\"",
     "JavascriptFilter 2/2 without var": "JavascriptFilter 2/2 without var"
 }

--- a/test/expected/04_fr_FR.json
+++ b/test/expected/04_fr_FR.json
@@ -15,6 +15,8 @@
     "SUB.NS.VAL 1.test 2": "",
     "JavascriptServiceSimpleQuote 1/2 with var \"{name}\".": "",
     "JavascriptServiceDoubleQuote 2/2 with var \"{name}\".": "",
+    "JavascriptServiceInstantSimpleQuote 1/2 with var \"{name}\".": "",
+    "JavascriptServiceInstantDoubleQuote 2/2 with var \"{name}\".": "",
     "JavascriptFilter 1/2 with var \"{name}\"": "",
     "JavascriptFilter 2/2 without var": ""
 }

--- a/test/expected/05_en_US.json
+++ b/test/expected/05_en_US.json
@@ -15,6 +15,8 @@
     "SUB.NS.VAL 1.test 2": "SUB.NS.VAL 1.test 2",
     "JavascriptServiceSimpleQuote 1/2 with var \"{name}\".": "JavascriptServiceSimpleQuote 1/2 with var \"{name}\".",
     "JavascriptServiceDoubleQuote 2/2 with var \"{name}\".": "JavascriptServiceDoubleQuote 2/2 with var \"{name}\".",
+    "JavascriptServiceInstantSimpleQuote 1/2 with var \"{name}\".": "JavascriptServiceInstantSimpleQuote 1/2 with var \"{name}\".",
+    "JavascriptServiceInstantDoubleQuote 2/2 with var \"{name}\".": "JavascriptServiceInstantDoubleQuote 2/2 with var \"{name}\".",
     "JavascriptFilter 1/2 with var \"{name}\"": "JavascriptFilter 1/2 with var \"{name}\"",
     "JavascriptFilter 2/2 without var": "JavascriptFilter 2/2 without var",
     "config:translation 00": "config:translation 00",

--- a/test/fixtures/titleService.js
+++ b/test/fixtures/titleService.js
@@ -6,6 +6,8 @@ angular.module('titleService', [])
 
     $translate('JavascriptServiceSimpleQuote 1/2 with var "{name}".', {name: 'name'});
     $translate("JavascriptServiceDoubleQuote 2/2 with var \"{name}\".", {name: 'name'});
+    $translate.instant('JavascriptServiceInstantSimpleQuote 1/2 with var "{name}".', {name: 'name'});
+    $translate.instant("JavascriptServiceInstantDoubleQuote 2/2 with var \"{name}\".", {name: 'name'});
 
     var titleService = {
     };


### PR DESCRIPTION
Thank you for maintaining grunt-angular-translate. I was missing the $translate.instant() support (also requested in #18). Here we go!

I could not run 'grunt test', but 'grunt clean i18nextract && nodeunit test/angular-translate_test.js' worked for me. What do I miss to get 'grunt test' running? I installed all packages via 'npm install' and installed nodeunit via 'npm install nodeunit -g'
