### PR TITLE
Do not remove non-namespaced strings when namespace option is enabled.

### DIFF
--- a/tasks/lib/translations.js
+++ b/tasks/lib/translations.js
@@ -199,9 +199,6 @@ Translations.cleanParents = function (obj) {
       return (k < splitted.length - 1) ? m + '.' + v : m;
     });
     keepKeys.push(v);
-    _.remove(keepKeys, function (v) {
-      return v === splittedNS;
-    });
   });
   var cleanedObject = {};
   _.forEach(obj, function (v,k) {

--- a/tasks/lib/translations.js
+++ b/tasks/lib/translations.js
@@ -194,11 +194,17 @@ Translations.cleanParents = function (obj) {
   var keys = _.sortBy(_.keys(obj));
   var keepKeys = [];
   _.forEach(keys, function (v) {
-    var splitted = v.split('.');
-    var splittedNS = _.reduce(splitted, function (m, v, k, l) {
-      return (k < splitted.length - 1) ? m + '.' + v : m;
-    });
     keepKeys.push(v);
+    var splitted = v.split('.');
+    for (var i = 1; i < splitted.length; i++)
+    {
+      var splittedNS = _.reduce(splitted.slice(0, i), function (m, v, k, l) {
+        return (k < splitted.length - 1) ? m + '.' + v : m;
+      });
+      _.remove(keepKeys, function (v) {
+        return v === splittedNS;
+      });
+    }
   });
   var cleanedObject = {};
   _.forEach(obj, function (v,k) {

--- a/test/expected/00_fr_FR.json
+++ b/test/expected/00_fr_FR.json
@@ -8,6 +8,7 @@
     "HtmlDirectivePluralFirst": "{NB, plural, one{HtmlDirectivePluralFirst for one!} other{# HtmlDirectivePluralFirst for others!}",
     "HtmlDirectiveStandalone": "",
     "HtmlNgBindHtml Key ' 1/1": "",
+    "NONAMESPACE": "",
     "SUB.NAMESPACE.VAL 1": "",
     "SUB.NAMESPACE.VAL 2": "",
     "SUB.NS.VAL 1": "",

--- a/test/expected/01_fr_FR.json
+++ b/test/expected/01_fr_FR.json
@@ -8,6 +8,7 @@
     "HtmlDirectivePluralFirst": "{NB, plural, one{HtmlDirectivePluralFirst for one!} other{# HtmlDirectivePluralFirst for others!}",
     "HtmlDirectiveStandalone": null,
     "HtmlNgBindHtml Key ' 1/1": null,
+    "NONAMESPACE": null,
     "SUB.NAMESPACE.VAL 1": null,
     "SUB.NAMESPACE.VAL 2": null,
     "SUB.NS.VAL 1": null,

--- a/test/expected/02_fr_FR.json
+++ b/test/expected/02_fr_FR.json
@@ -8,6 +8,7 @@
     "HtmlDirectivePluralFirst": "{NB, plural, one{HtmlDirectivePluralFirst for one!} other{# HtmlDirectivePluralFirst for others!}",
     "HtmlDirectiveStandalone": "",
     "HtmlNgBindHtml Key ' 1/1": "",
+    "NONAMESPACE": "",
     "SUB.NAMESPACE.VAL 1": "",
     "SUB.NAMESPACE.VAL 2": "",
     "SUB.NS.VAL 1": "",

--- a/test/expected/03_fr_FR.json
+++ b/test/expected/03_fr_FR.json
@@ -8,6 +8,7 @@
     "HtmlDirectivePluralFirst": "{NB, plural, one{HtmlDirectivePluralFirst for one!} other{# HtmlDirectivePluralFirst for others!}",
     "HtmlDirectiveStandalone": "",
     "HtmlNgBindHtml Key ' 1/1": "",
+    "NONAMESPACE": "",
     "SUB.NAMESPACE.VAL 1": "",
     "SUB.NAMESPACE.VAL 2": "",
     "SUB.NS.VAL 1": "",

--- a/test/expected/04_en_US.json
+++ b/test/expected/04_en_US.json
@@ -8,6 +8,7 @@
     "HtmlDirectivePluralFirst": "{NB, plural, one{HtmlDirectivePluralFirst for one!} other{# HtmlDirectivePluralFirst for others!}",
     "HtmlDirectiveStandalone": "HtmlDirectiveStandalone",
     "HtmlNgBindHtml Key ' 1/1": "HtmlNgBindHtml Key ' 1/1",
+    "NONAMESPACE": "NONAMESPACE",
     "SUB.NAMESPACE.VAL 1": "SUB.NAMESPACE.VAL 1",
     "SUB.NAMESPACE.VAL 2": "SUB.NAMESPACE.VAL 2",
     "SUB.NS.VAL 1": "SUB.NS.VAL 1",

--- a/test/expected/04_fr_FR.json
+++ b/test/expected/04_fr_FR.json
@@ -8,6 +8,7 @@
     "HtmlDirectivePluralFirst": "{NB, plural, one{HtmlDirectivePluralFirst for one!} other{# HtmlDirectivePluralFirst for others!}",
     "HtmlDirectiveStandalone": "",
     "HtmlNgBindHtml Key ' 1/1": "",
+    "NONAMESPACE": "",
     "SUB.NAMESPACE.VAL 1": "",
     "SUB.NAMESPACE.VAL 2": "",
     "SUB.NS.VAL 1": "",

--- a/test/expected/05_en_US.json
+++ b/test/expected/05_en_US.json
@@ -8,6 +8,7 @@
     "HtmlDirectivePluralFirst": "{NB, plural, one{HtmlDirectivePluralFirst for one!} other{# HtmlDirectivePluralFirst for others!}",
     "HtmlDirectiveStandalone": "HtmlDirectiveStandalone",
     "HtmlNgBindHtml Key ' 1/1": "HtmlNgBindHtml Key ' 1/1",
+    "NONAMESPACE": "NONAMESPACE",
     "SUB.NAMESPACE.VAL 1": "SUB.NAMESPACE.VAL 1",
     "SUB.NAMESPACE.VAL 2": "SUB.NAMESPACE.VAL 2",
     "SUB.NS.VAL 1": "SUB.NS.VAL 1",

--- a/test/expected/06_fr_FR.json
+++ b/test/expected/06_fr_FR.json
@@ -1,4 +1,5 @@
 {
+    "NONAMESPACE": "",
     "SUB": {
         "NAMESPACE": {
             "VAL 1": "",

--- a/test/expected/07_en_US.json
+++ b/test/expected/07_en_US.json
@@ -1,4 +1,5 @@
 {
+    "NONAMESPACE": null,
     "SUB": {
         "NAMESPACE": {
             "VAL 1": null,

--- a/test/expected/07_fr_FR.json
+++ b/test/expected/07_fr_FR.json
@@ -1,4 +1,5 @@
 {
+    "NONAMESPACE": "NONAMESPACE",
     "SUB": {
         "NAMESPACE": {
             "VAL 1": "SUB.NAMESPACE.VAL 1",

--- a/test/expected/08_fr_FR.json
+++ b/test/expected/08_fr_FR.json
@@ -1,4 +1,5 @@
 {
+    "NONAMESPACE": null,
     "SUB": {
         "NAMESPACE": {
             "VAL 1": "My default SUB.NAMESPACE.VAL 1",

--- a/test/fixtures/index_namespace.html
+++ b/test/fixtures/index_namespace.html
@@ -13,6 +13,7 @@
   TEST CASE - Directive HTML translate SUB.NAMESPACE
 -->
 <p>
+  <span translate style="text-align:center">NONAMESPACE</span>
   <span translate style="text-align:center">SUB.NAMESPACE.VAL 1</span> - <span translate style="text-align:center">SUB.NAMESPACE.VAL 2</span>
   <span translate style="text-align:center">SUB.NS.VAL 1</span> - <span translate style="text-align:center">SUB.NS.VAL 2</span>
   <span translate style="text-align:center">SUB.NS.VAL 1.test1</span> - <span translate style="text-align:center">SUB.NS.VAL 1.test 2</span>


### PR DESCRIPTION
If you enable namespaces grunt-angular-translate will remove non-namespaced strings. So it will e.g. include `MODULE.MYTEXT`, but will remove `MYTEXT`.

Actually this seems to be by design, but I think it is nonsense and confusing. it's definitely not what is expected by the user, and actually it can make some sense to have non-namespaced strings for globally available texts.