### PR TITLE
added _.isString check to recurseData for loop

### DIFF
--- a/tasks/angular-translate.js
+++ b/tasks/angular-translate.js
@@ -242,7 +242,9 @@ module.exports = function (grunt) {
       var content = _file.readJSON(file);
       var recurseData = _recurseObject(content);
       for (var i in recurseData) {
-        results[ recurseData[i].trim() ] = '';
+        if (_.isString(recurseData[i])) {
+          results[ recurseData[i].trim() ] = '';
+        }
       }
     });
 


### PR DESCRIPTION
The for loop was catching other non-string properties added to the array prototype (e.g. functions), causing exceptions to be thrown when trim() was called on them.
