### PR TITLE
Change regex such that keyword translate in string in html tag does not ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-markdox": "^0.1.0"
   },
   "peerDependencies": {

--- a/tasks/angular-translate.js
+++ b/tasks/angular-translate.js
@@ -148,7 +148,7 @@ module.exports = function (grunt) {
       commentDoubleQuote: '\\/\\*\\s*i18nextract\\s*\\*\\/"((?:\\\\.|[^"\\\\])*)"',
       HtmlFilterSimpleQuote: escapeRegExp(interpolation.startDelimiter) + '\\s*\'((?:\\\\.|[^\'\\\\])*)\'\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
       HtmlFilterDoubleQuote: escapeRegExp(interpolation.startDelimiter) + '\\s*"((?:\\\\.|[^"\\\\\])*)"\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
-      HtmlDirective: '<[^>]*translate[^{>]*>([^<]*)<\/[^>]*>',
+      HtmlDirective: '<(?:[^>"]|"(?:[^"]|/")*")*\\stranslate(?:\\s[^{>]*>|>)([^<]*)<\/[^>]*>',
       HtmlDirectiveStandalone: 'translate="((?:\\\\.|[^"\\\\])*)"',
       HtmlDirectivePluralLast: 'translate="((?:\\\\.|[^"\\\\])*)".*angular-plural-extract="((?:\\\\.|[^"\\\\])*)"',
       HtmlDirectivePluralFirst: 'angular-plural-extract="((?:\\\\.|[^"\\\\])*)".*translate="((?:\\\\.|[^"\\\\])*)"',

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -59,6 +59,13 @@
   <span translate style="text-align:center">HtmlDirective 1/2 &é"'(-è_çà)=$^ù!:;,}@^`[{#~@Ùô</span> - <span translate style="text-align:center">HtmlDirective 2/2</span>
 </p>
 
+<!--
+  TEST CASE - Keyword "translate" in string in HTML tag should not register enclosed text as a key
+-->
+<p>
+  <span style="text-align:center" title="{{ TEST.KEY | translate }}">HtmlDirective translate in string</span>
+</p>
+
 </body>
 
 </html>


### PR DESCRIPTION
...automatically cause the enclosing text to be a key