### PR TITLE
Added key as text feature

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -195,12 +195,21 @@ module.exports = function(grunt) {
       extra_regexs: {
         prefix:   '10_',
         suffix:   '.json',
-        src:      [ 'test/fixtures/*.html', 'test/fixtures/*.js' ],
+        src:      [ 'test/fixtures/*.html' ],
         lang:     ['fr_FR'],
         customRegex: [
           'tt-default="\'((?:\\\\.|[^\'\\\\])*)\'\\|translate"'
         ],
         dest:     'tmp'
+      },
+
+      key_as_text: {
+        prefix:   '11_',
+        suffix:   '.json',
+        src: ['test/fixtures/index_key_as_text.html'],
+        lang: ['en_US'],
+        dest: 'tmp',
+        keyAsText: true
       }
 
     },

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Options src and jsonSrc may be specified according to the grunt Configuring task
 - [dest](#dest)
 - [safeMode](#safeMode)
 - [stringifyOptions](#stringifyOptions)
+- [keyAsText](#keyAsText)
 
 #### src
 
@@ -229,6 +230,12 @@ Default: `false`
 
 If stringifyOptions is set to `true` the output will be sort (case insensitive).
 If stringifyOptions is an `object`, you can easily check [json-stable-stringify](https://github.com/substack/json-stable-stringify) README.
+
+#### keyAsText
+Type: `Boolean`
+Default: `false`
+
+If keyAsText is set to `true` translations keys works also as value for this translation.
 
 ## Test
 

--- a/tasks/angular-translate.js
+++ b/tasks/angular-translate.js
@@ -39,7 +39,8 @@ module.exports = function (grunt) {
       suffix = this.data.suffix || '.json',
       customRegex = _.isArray(this.data.customRegex) ? this.data.customRegex : [],
       stringify_options = this.data.stringifyOptions || null,
-      results = {};
+      results = {},
+      keyAsText = this.data.keyAsText || false;
 
     var customStringify = function (val) {
       if (stringify_options) {
@@ -134,7 +135,11 @@ module.exports = function (grunt) {
 
           if( regexName !== "JavascriptServiceArraySimpleQuote" &&
               regexName !== "JavascriptServiceArrayDoubleQuote") {
-            results[ translationKey ] = translationDefaultValue;
+            if(keyAsText === true && translationDefaultValue.length === 0) {
+              results[ translationKey ] = translationKey;
+            } else {
+              results[ translationKey ] = translationDefaultValue;
+            }
           }
 
 

--- a/test/angular-translate_test.js
+++ b/test/angular-translate_test.js
@@ -132,6 +132,16 @@ exports.i18nextract = {
     test.equal( actual, expected, 'Should equal.' );
 
     test.done();
+  },
+
+  key_as_text: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read( 'tmp/11_en_US.json' );
+    var expected = grunt.file.read( 'test/expected/11_en_US.json' );
+    test.equal( actual, expected, 'Should equal.' );
+
+    test.done();
   }
 
 };

--- a/test/expected/11_en_US.json
+++ b/test/expected/11_en_US.json
@@ -1,0 +1,5 @@
+{
+    "This is text to translate": "This is text to translate",
+    "But I want to have the text as a key": "But I want to have the text as a key",
+    "For example this paragraph will be a key and value for default language": "For example this paragraph will be a key and value for default language"
+}

--- a/test/fixtures/index_key_as_text.html
+++ b/test/fixtures/index_key_as_text.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>grunt-angular-translate test page</title>
+</head>
+<body>
+
+<p translate>This is text to translate</p>
+<p translate>But I want to have the text as a key</p>
+<p translate>For example this paragraph will be a key and value for default language</p>
+
+</body>
+</html>


### PR DESCRIPTION
This feature if keyAsText is set to `true`on configuration, translations keys will work also as value for this translation.

You can see an example on test/fixtures/index_key_as_text.html and master/test/expected/11_en_US.json.