### PR TITLE
Add support for angular one time binding '::'

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-nodeunit": "^0.4.1",
     "grunt-markdox": "^0.1.0"
   },
   "peerDependencies": {

--- a/tasks/angular-translate.js
+++ b/tasks/angular-translate.js
@@ -146,8 +146,8 @@ module.exports = function (grunt) {
     var regexs = {
       commentSimpleQuote: '\\/\\*\\s*i18nextract\\s*\\*\\/\'((?:\\\\.|[^\'\\\\])*)\'',
       commentDoubleQuote: '\\/\\*\\s*i18nextract\\s*\\*\\/"((?:\\\\.|[^"\\\\])*)"',
-      HtmlFilterSimpleQuote: escapeRegExp(interpolation.startDelimiter) + '\\s*\'((?:\\\\.|[^\'\\\\])*)\'\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
-      HtmlFilterDoubleQuote: escapeRegExp(interpolation.startDelimiter) + '\\s*"((?:\\\\.|[^"\\\\\])*)"\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
+      HtmlFilterSimpleQuote: escapeRegExp(interpolation.startDelimiter) + '\\s*(?:::)?\'((?:\\\\.|[^\'\\\\])*)\'\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
+      HtmlFilterDoubleQuote: escapeRegExp(interpolation.startDelimiter) + '\\s*(?:::)?"((?:\\\\.|[^"\\\\\])*)"\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
       HtmlDirective: '<[^>]*translate[^{>]*>([^<]*)<\/[^>]*>',
       HtmlDirectiveStandalone: 'translate="((?:\\\\.|[^"\\\\])*)"',
       HtmlDirectivePluralLast: 'translate="((?:\\\\.|[^"\\\\])*)".*angular-plural-extract="((?:\\\\.|[^"\\\\])*)"',

--- a/test/expected/00_fr_FR.json
+++ b/test/expected/00_fr_FR.json
@@ -1,4 +1,5 @@
 {
+    "HtmlFilterSimpleQuoteOneTimeBinding": "",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "",
     "HtmlFilterDoubleQuote{} on same line 2/2": "",

--- a/test/expected/01_fr_FR.json
+++ b/test/expected/01_fr_FR.json
@@ -1,4 +1,5 @@
 {
+    "HtmlFilterSimpleQuoteOneTimeBinding": null,
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": null,
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": null,
     "HtmlFilterDoubleQuote{} on same line 2/2": null,

--- a/test/expected/02_fr_FR.json
+++ b/test/expected/02_fr_FR.json
@@ -1,4 +1,5 @@
 {
+    "HtmlFilterSimpleQuoteOneTimeBinding": "",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "",
     "HtmlFilterDoubleQuote{} on same line 2/2": "",

--- a/test/expected/04_en_US.json
+++ b/test/expected/04_en_US.json
@@ -1,4 +1,5 @@
 {
+    "HtmlFilterSimpleQuoteOneTimeBinding": "HtmlFilterSimpleQuoteOneTimeBinding",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "HtmlFilterDoubleQuote{} interp\"olation {{xx}}",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "HtmlFilterDoubleQuote{} {{var}}on same line 1/2",
     "HtmlFilterDoubleQuote{} on same line 2/2": "HtmlFilterDoubleQuote{} on same line 2/2",

--- a/test/expected/04_fr_FR.json
+++ b/test/expected/04_fr_FR.json
@@ -1,4 +1,5 @@
 {
+    "HtmlFilterSimpleQuoteOneTimeBinding": "",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "",
     "HtmlFilterDoubleQuote{} on same line 2/2": "",

--- a/test/expected/05_en_US.json
+++ b/test/expected/05_en_US.json
@@ -1,4 +1,5 @@
 {
+    "HtmlFilterSimpleQuoteOneTimeBinding": "HtmlFilterSimpleQuoteOneTimeBinding",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "HtmlFilterDoubleQuote{} interp\"olation {{xx}}",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "HtmlFilterDoubleQuote{} {{var}}on same line 1/2",
     "HtmlFilterDoubleQuote{} on same line 2/2": "HtmlFilterDoubleQuote{} on same line 2/2",

--- a/test/expected/10_fr_FR.json
+++ b/test/expected/10_fr_FR.json
@@ -1,4 +1,5 @@
 {
+    "HtmlFilterSimpleQuoteOneTimeBinding": "",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "",
     "HtmlFilterDoubleQuote{} on same line 2/2": "",

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -25,6 +25,16 @@
 <!--
   TEST CASE - Filter HTML
   Interpolation: {{ }}
+  Simple quote
+  One time binding
+-->
+<header style="font-family:'Helvetica Neue'">
+  <h1 style="color:red">{{ ::'HtmlFilterSimpleQuoteOneTimeBinding' | translate }}</h1>
+</header>
+
+<!--
+  TEST CASE - Filter HTML
+  Interpolation: {{ }}
   Double quote
   Variables
   Spaces


### PR DESCRIPTION
Angular 1.3 has introduced one time binding. Sometimes it's useful to
use the angular-translate filter without setting up a watcher. For
example:

```
    <i class="fa fa-info-circle tooltip-info"
       tooltip-placement="up"
       tooltip="{{ ::'tooltip.message' | translate }}">
    </i>
```

This commit updates the filter regular expressions along with unit
tests.