### PR TITLE
fix(interpolation): fixed escaped interpolation string handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-angular-translate",
-  "version": "0.3.3",
+  "version": "0.3.4.rc1",
   "description": "Extract all the translation keys for angular-translate project",
   "main": "Gruntfile.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/angular-translate/grunt-angular-translate.git"
+    "url": "git://github.com/myukselen/grunt-angular-translate.git"
   },
   "keywords": [
     "AngularJS",
@@ -50,7 +50,6 @@
       "url": "https://github.com/angular-translate/grunt-angular-translate/blob/master/LICENSEgit "
     }
   ],
-  "gitHead": "dd655f85e3b4c59b7f3ac5ebf3f1ccad69876bb8",
   "readmeFilename": "README.md",
   "dependencies": {
     "flat": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-angular-translate",
-  "version": "0.3.4.rc1",
+  "version": "0.3.4",
   "description": "Extract all the translation keys for angular-translate project",
   "main": "Gruntfile.js",
   "directories": {

--- a/tasks/angular-translate.js
+++ b/tasks/angular-translate.js
@@ -46,7 +46,15 @@ module.exports = function (grunt) {
     // Use to escape some char into regex patterns
     var escapeRegExp = function (str) {
       return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
-    }
+    };
+
+    // Escape interpolation characters in the given str
+    var escapeRegExpInterpolation = function (str) {
+      return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\\\\\$&");
+    };
+
+    var escapedInterpolationStartRegex = new RegExp(escapeRegExpInterpolation(interpolation.startDelimiter), 'g'),
+        escapedInterpolationEndRegex = new RegExp(escapeRegExpInterpolation(interpolation.endDelimiter), 'g');
 
     // Extract regex strings from content and feed results object
     var _extractTranslation = function (regexName, regex, content, results) {
@@ -94,19 +102,30 @@ module.exports = function (grunt) {
 
           switch (regexName) {
             case "commentSimpleQuote":
-            case "HtmlFilterSimpleQuote":
             case "JavascriptServiceSimpleQuote":
             case "JavascriptServiceInstantSimpleQuote":
             case "JavascriptFilterSimpleQuote":
-            case "HtmlNgBindHtml":
               translationKey = translationKey.replace(/\\\'/g, "'");
               break;
+            case "HtmlFilterSimpleQuote":
+              translationKey = translationKey.replace(/\\\'/g, "'");
+              translationKey = translationKey.replace(escapedInterpolationStartRegex, interpolation.startDelimiter);
+              translationKey = translationKey.replace(escapedInterpolationEndRegex, interpolation.endDelimiter);
+              break;
+            case "HtmlNgBindHtml":
+              translationKey = translationKey.replace(/\\\'/g, "'");
+              translationKey = translationKey.replace(/&quot;/g, '"');
+              break;
             case "commentDoubleQuote":
-            case "HtmlFilterDoubleQuote":
             case "JavascriptServiceDoubleQuote":
             case "JavascriptServiceInstantDoubleQuote":
             case "JavascriptFilterDoubleQuote":
               translationKey = translationKey.replace(/\\\"/g, '"');
+              break;
+            case "HtmlFilterDoubleQuote":
+              translationKey = translationKey.replace(/\\\"/g, '"');
+              translationKey = translationKey.replace(escapedInterpolationStartRegex, interpolation.startDelimiter);
+              translationKey = translationKey.replace(escapedInterpolationEndRegex, interpolation.endDelimiter);
               break;
             case "JavascriptServiceArraySimpleQuote":
             case "JavascriptServiceArrayDoubleQuote":
@@ -175,7 +194,7 @@ module.exports = function (grunt) {
       HtmlDirectivePluralLast: 'translate="((?:\\\\.|[^"\\\\])*)".*angular-plural-extract="((?:\\\\.|[^"\\\\])*)"',
       HtmlDirectivePluralFirst: 'angular-plural-extract="((?:\\\\.|[^"\\\\])*)".*translate="((?:\\\\.|[^"\\\\])*)"',
       HtmlNgBindHtml: 'ng-bind-html="\\s*\'((?:\\\\.|[^\'\\\\])*)\'\\s*\\|\\s*translate(:.*?)?\\s*"',
-      HtmlNgBindHtmlTernary: 'ng-bind-html="\\s*([^?]*?[^:]*:[^|}]*)\\s*\\|\\s*translate(:.*?)?\\s*"',
+      HtmlNgBindHtmlTernary: 'ng-bind-html="\\s*([^\\"?]*?[^\\":]*:[^\\"|}]*)\\s*\\|\\s*translate(:.*?)?\\s*"',
       JavascriptServiceSimpleQuote: '\\$translate\\(\\s*\'((?:\\\\.|[^\'\\\\])*)\'[^\\)]*\\)',
       JavascriptServiceDoubleQuote: '\\$translate\\(\\s*"((?:\\\\.|[^"\\\\])*)"[^\\)]*\\)',
       JavascriptServiceArraySimpleQuote: '\\$translate\\((?:\\s*(\\[\\s*(?:(?:\'(?:(?:\\.|[^.*\'\\\\])*)\')\\s*,*\\s*)+\\s*\\])\\s*)\\)',

--- a/tasks/angular-translate.js
+++ b/tasks/angular-translate.js
@@ -23,6 +23,8 @@ module.exports = function (grunt) {
     if (!_.isArray(this.data.lang) || !this.data.lang.length) {
       grunt.fail('lang parameter is required.');
     }
+    // Check debug parameter
+    var debug = this.data.debug;
 
     // Declare all var from configuration
     var files = _file.expand(this.data.src),
@@ -159,10 +161,14 @@ module.exports = function (grunt) {
           var defaultValueByTranslationKey = function (translationKey, translationDefaultValue) {
             if (regexName !== "JavascriptServiceArraySimpleQuote" &&
               regexName !== "JavascriptServiceArrayDoubleQuote") {
+              var resultKey = translationKey;
+              if (debug) {
+                resultKey = regexName + '_' + translationKey;
+              }
               if (keyAsText === true && translationDefaultValue.length === 0) {
-                results[translationKey] = translationKey;
+                results[resultKey] = translationKey;
               } else {
-                results[translationKey] = translationDefaultValue;
+                results[resultKey] = translationDefaultValue;
               }
             }
           }
@@ -186,8 +192,8 @@ module.exports = function (grunt) {
       commentSimpleQuote: '\\/\\*\\s*i18nextract\\s*\\*\\/\'((?:\\\\.|[^\'\\\\])*)\'',
       commentDoubleQuote: '\\/\\*\\s*i18nextract\\s*\\*\\/"((?:\\\\.|[^"\\\\])*)"',
       HtmlFilterSimpleQuote: escapeRegExp(interpolation.startDelimiter) + '\\s*(?:::)?\'((?:\\\\.|[^\'\\\\])*)\'\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
-      HtmlFilterDoubleQuote: escapeRegExp(interpolation.startDelimiter) + '\\s*(?:::)?"((?:\\\\.|[^"\\\\\])*)"\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
-      HtmlFilterTernary: escapeRegExp(interpolation.startDelimiter) + '\\s*(?:::)?([^?]*\\?[^:]*:[^|}]*)\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
+      HtmlFilterDoubleQuote: escapeRegExp(interpolation.startDelimiter) + '\\s*(?:::)?"((?:\\\\.|[^"\\\\])+)"\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
+      HtmlFilterTernary: escapeRegExp(interpolation.startDelimiter) + '\\s*(?:::)?([^?\\n\\r]+\\?[^:\\n\\r]+:[^|}\\n\\r]+)\\s*\\|\\s*translate(:.*?)?\\s*' + escapeRegExp(interpolation.endDelimiter),
       HtmlDirective: '<(?:[^>"]|"(?:[^"]|\\/")*")*\\stranslate(?:>|\\s[^>]*>)([^<]*)',
       HtmlDirectiveSimpleQuote: '<(?:[^>"]|"(?:[^"]|\\/")*")*\\stranslate=\'([^\']*)\'[^>]*>([^<]*)',
       HtmlDirectiveDoubleQuote: '<(?:[^>"]|"(?:[^"]|\\/")*")*\\stranslate="([^"]*)"[^>]*>([^<]*)',

--- a/tasks/angular-translate.js
+++ b/tasks/angular-translate.js
@@ -117,6 +117,7 @@ module.exports = function (grunt) {
             case "HtmlNgBindHtml":
               translationKey = translationKey.replace(/\\\'/g, "'");
               translationKey = translationKey.replace(/&quot;/g, '"');
+              translationKey = translationKey.replace(/&le;/g, '≤');
               break;
             case "commentDoubleQuote":
             case "JavascriptServiceDoubleQuote":

--- a/test/expected/00_fr_FR.json
+++ b/test/expected/00_fr_FR.json
@@ -1,5 +1,6 @@
 {
     "HtmlFilterSimpleQuoteOneTimeBinding": "",
+    "HtmlFilterSimpleQuote with {{varName}}": "",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "",
     "HtmlFilterDoubleQuote{} on same line 2/2": "",

--- a/test/expected/01_fr_FR.json
+++ b/test/expected/01_fr_FR.json
@@ -1,5 +1,6 @@
 {
     "HtmlFilterSimpleQuoteOneTimeBinding": null,
+    "HtmlFilterSimpleQuote with {{varName}}": null,
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": null,
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": null,
     "HtmlFilterDoubleQuote{} on same line 2/2": null,

--- a/test/expected/02_fr_FR.json
+++ b/test/expected/02_fr_FR.json
@@ -1,5 +1,6 @@
 {
     "HtmlFilterSimpleQuoteOneTimeBinding": "",
+    "HtmlFilterSimpleQuote with {{varName}}": "",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "",
     "HtmlFilterDoubleQuote{} on same line 2/2": "",

--- a/test/expected/04_en_US.json
+++ b/test/expected/04_en_US.json
@@ -1,5 +1,6 @@
 {
     "HtmlFilterSimpleQuoteOneTimeBinding": "HtmlFilterSimpleQuoteOneTimeBinding",
+    "HtmlFilterSimpleQuote with {{varName}}": "HtmlFilterSimpleQuote with {{varName}}",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "HtmlFilterDoubleQuote{} interp\"olation {{xx}}",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "HtmlFilterDoubleQuote{} {{var}}on same line 1/2",
     "HtmlFilterDoubleQuote{} on same line 2/2": "HtmlFilterDoubleQuote{} on same line 2/2",

--- a/test/expected/04_fr_FR.json
+++ b/test/expected/04_fr_FR.json
@@ -1,5 +1,6 @@
 {
     "HtmlFilterSimpleQuoteOneTimeBinding": "",
+    "HtmlFilterSimpleQuote with {{varName}}": "",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "",
     "HtmlFilterDoubleQuote{} on same line 2/2": "",

--- a/test/expected/05_en_US.json
+++ b/test/expected/05_en_US.json
@@ -1,5 +1,6 @@
 {
     "HtmlFilterSimpleQuoteOneTimeBinding": "HtmlFilterSimpleQuoteOneTimeBinding",
+    "HtmlFilterSimpleQuote with {{varName}}": "HtmlFilterSimpleQuote with {{varName}}",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "HtmlFilterDoubleQuote{} interp\"olation {{xx}}",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "HtmlFilterDoubleQuote{} {{var}}on same line 1/2",
     "HtmlFilterDoubleQuote{} on same line 2/2": "HtmlFilterDoubleQuote{} on same line 2/2",

--- a/test/expected/10_1_fr_FR.json
+++ b/test/expected/10_1_fr_FR.json
@@ -1,5 +1,6 @@
 {
     "HtmlFilterSimpleQuoteOneTimeBinding": "",
+    "HtmlFilterSimpleQuote with {{varName}}": "",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "",
     "HtmlFilterDoubleQuote{} on same line 2/2": "",

--- a/test/expected/10_fr_FR.json
+++ b/test/expected/10_fr_FR.json
@@ -1,5 +1,6 @@
 {
     "HtmlFilterSimpleQuoteOneTimeBinding": "",
+    "HtmlFilterSimpleQuote with {{varName}}": "",
     "HtmlFilterDoubleQuote{} interp\"olation {{xx}}": "",
     "HtmlFilterDoubleQuote{} {{var}}on same line 1/2": "",
     "HtmlFilterDoubleQuote{} on same line 2/2": "",

--- a/test/expected/template.pot
+++ b/test/expected/template.pot
@@ -77,6 +77,10 @@ msgid "HtmlFilterDoubleQuote{} on same line 2/2"
 msgstr ""
 
 msgctxt ""
+msgid "HtmlFilterSimpleQuote with {{varName}}"
+msgstr ""
+
+msgctxt ""
 msgid "HtmlFilterSimpleQuoteOneTimeBinding"
 msgstr ""
 

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -35,6 +35,16 @@
 <!--
   TEST CASE - Filter HTML
   Interpolation: {{ }}
+  Simple quote
+  Variables
+-->
+<header style="font-family:'Helvetica Neue'">
+  <h1 description="{{ 'HtmlFilterSimpleQuote with \{\{varName\}\}' | translate:{varName: 'Variables'} }}">Inspect 'description' attribute</h1>
+</header>
+
+<!--
+  TEST CASE - Filter HTML
+  Interpolation: {{ }}
   Double quote
   Variables
   Spaces

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -29,6 +29,11 @@
   One time binding
 -->
 <header style="font-family:'Helvetica Neue'">
+  <div>
+    <img ng-src="{{sectionToTriggerBrokenTernaryRegex || doNotSpanMultipleLines}}">
+    <button message="Are you really <b>sure</b> you want to delete this?">Delete</button>
+    <p style="display: block;">just fulfilling ternary operator</p>
+  </div>
   <h1 style="color:red">{{ ::'HtmlFilterSimpleQuoteOneTimeBinding' | translate }}</h1>
 </header>
 


### PR DESCRIPTION
Interpolation string should be escaped properly when used in an interpolation. This is handled in HtmlFilterDoubleQuote and HtmlFilterSimpleQuote translationKey processing.